### PR TITLE
`@RequestBody`의 값 바인딩

### DIFF
--- a/src/main/java/com/minchul/javalab/requestbody/HelloController.java
+++ b/src/main/java/com/minchul/javalab/requestbody/HelloController.java
@@ -1,0 +1,21 @@
+package com.minchul.javalab.requestbody;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/requestBody")
+public class HelloController {
+
+    @PostMapping("/modelAttribute")
+    public String modelAttributeNoSetter(@ModelAttribute final RequestDto requestDto) {
+        log.info("저장 로직 실행!!");
+        log.info("이름={}, 나이={}, ", requestDto.getName(), requestDto.getAge());
+        return "OK!";
+    }
+
+}

--- a/src/main/java/com/minchul/javalab/requestbody/HelloController.java
+++ b/src/main/java/com/minchul/javalab/requestbody/HelloController.java
@@ -3,6 +3,7 @@ package com.minchul.javalab.requestbody;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,7 +20,7 @@ public class HelloController {
     }
 
     @PostMapping("/requestBody")
-    public String requestBodyNoSetter(@ModelAttribute final RequestDto requestDto) {
+    public String requestBodyNoSetter(@RequestBody final RequestDto requestDto) {
         log.info("저장 로직 실행!!");
         log.info("이름={}, 나이={}, ", requestDto.getName(), requestDto.getAge());
         return "OK!";

--- a/src/main/java/com/minchul/javalab/requestbody/HelloController.java
+++ b/src/main/java/com/minchul/javalab/requestbody/HelloController.java
@@ -8,11 +8,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/requestBody")
+@RequestMapping("/hello")
 public class HelloController {
 
     @PostMapping("/modelAttribute")
     public String modelAttributeNoSetter(@ModelAttribute final RequestDto requestDto) {
+        log.info("저장 로직 실행!!");
+        log.info("이름={}, 나이={}, ", requestDto.getName(), requestDto.getAge());
+        return "OK!";
+    }
+
+    @PostMapping("/requestBody")
+    public String requestBodyNoSetter(@ModelAttribute final RequestDto requestDto) {
         log.info("저장 로직 실행!!");
         log.info("이름={}, 나이={}, ", requestDto.getName(), requestDto.getAge());
         return "OK!";

--- a/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
+++ b/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
@@ -9,13 +9,12 @@ public class RequestDto {
     private String name;
     private Long age;
 
-    private RequestDto(String name, Long age) {
-        this.name = name;
-        this.age = age;
-    }
-
-    public static RequestDto of(final String name, final Long age) {
-        return new RequestDto(name, age);
-    }
-
+//    private RequestDto(String name, Long age) {
+//        this.name = name;
+//        this.age = age;
+//    }
+//
+//    public static RequestDto of(final String name, final Long age) {
+//        return new RequestDto(name, age);
+//    }
 }

--- a/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
+++ b/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
@@ -1,8 +1,10 @@
 package com.minchul.javalab.requestbody;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class RequestDto {
     private String name;
     private Long age;

--- a/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
+++ b/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
@@ -4,8 +4,18 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
+//@Setter
 public class RequestDto {
     private String name;
     private Long age;
+
+    private RequestDto(String name, Long age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public static RequestDto of(final String name, final Long age) {
+        return new RequestDto(name, age);
+    }
+
 }

--- a/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
+++ b/src/main/java/com/minchul/javalab/requestbody/RequestDto.java
@@ -1,0 +1,9 @@
+package com.minchul.javalab.requestbody;
+
+import lombok.Getter;
+
+@Getter
+public class RequestDto {
+    private String name;
+    private Long age;
+}


### PR DESCRIPTION
`@ModelAttribute`는 적절한 생성자와 `setter`가 필요하다. **프로퍼티 접근법 사용**

`@RequestBody`는 `JSON`통신시에 `Jackson2HttpMessageConverter `을 사용하기 때문에 `ObjectMapper`를 통해 `JSON`을 `Java Object`로 변환하기 때문에 `setter`가 필요하지 않다.

[정리글](https://github.com/MinChul-Son/My_Develope_Diary/blob/main/Spring/%40RequestBody%EC%99%80%20Setter.md)

